### PR TITLE
Align repo with official Obsidian plugin structure

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Create a report to help us improve the plugin
+labels: bug
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment**
+ - OS: [e.g. Windows 11]
+ - Obsidian version: [e.g. 1.5.3]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this plugin
+labels: enhancement
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build plugin
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repo is crafted for structured development, modular scaling, and joyful col
 ## 🧰 Features
 
 - 🧠 Obsidian plugin scaffold in TypeScript
-- ⚙️ VaultOS-ready modular structure (`src/`, `ops/`, `config/`, `dist/`)
+- ✅ Follows the official Obsidian plugin folder structure (`src/`, `dist/`)
 - 📦 Rollup build system with `manifest.json`
 - 📁 Ready-to-use GitHub Actions and PR templates
 - 💬 Discussions and sponsor links for community-driven growth
@@ -48,9 +48,12 @@ After building, copy the contents of `/dist` into your Obsidian vault’s `.obsi
 ```plaintext
 src/           → TypeScript plugin source
 dist/          → Compiled output used by Obsidian
-ops/           → Plugin orchestration logic
-config/        → Static metadata and module configs
-.github/       → GitHub Actions, PR/issue templates
+.github/       → Community files (issues, PR templates, CI)
+manifest.json  → Plugin manifest
+package.json   → Build and dependency config
+rollup.config.js → Bundler setup
+tsconfig.json  → TypeScript options
+styles.css     → Optional styling
 ```
 
 ---

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "temp-repo-obsidian-plugin",
+  "name": "Temp Repo Obsidian Plugin",
+  "version": "0.0.1",
+  "minAppVersion": "0.15.0",
+  "description": "Example plugin scaffold",
+  "author": "PtiCalin",
+  "authorUrl": "https://github.com/PtiCalin",
+  "isDesktopOnly": false
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "temp_repo-obsidian-plugin",
+  "version": "0.0.1",
+  "description": "Obsidian plugin example",
+  "main": "dist/main.js",
+  "scripts": {
+    "dev": "rollup -c -w",
+    "build": "rollup -c"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^24.1.0",
+    "@rollup/plugin-node-resolve": "^15.2.3",
+    "@rollup/plugin-typescript": "^11.1.2",
+    "rollup": "^3.29.0",
+    "rollup-plugin-css-only": "^4.3.0",
+    "rollup-plugin-terser": "^7.0.2",
+    "typescript": "^5.0.4",
+    "obsidian": "1.5.3"
+  },
+  "license": "MIT"
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,22 @@
+import typescript from '@rollup/plugin-typescript';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import css from 'rollup-plugin-css-only';
+import { terser } from 'rollup-plugin-terser';
+
+export default {
+  input: 'src/main.ts',
+  output: {
+    dir: 'dist',
+    sourcemap: false,
+    format: 'cjs'
+  },
+  external: ['obsidian'],
+  plugins: [
+    typescript(),
+    nodeResolve({ browser: true }),
+    commonjs(),
+    css({ output: 'styles.css' }),
+    terser()
+  ]
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,63 @@
+import { App, Plugin, PluginSettingTab, Setting, Notice } from 'obsidian';
+
+interface SamplePluginSettings {
+mySetting: string;
+}
+
+const DEFAULT_SETTINGS: SamplePluginSettings = {
+mySetting: 'default'
+};
+
+export default class SamplePlugin extends Plugin {
+settings: SamplePluginSettings;
+
+async onload() {
+console.log('Loading plugin ' + this.manifest.id);
+await this.loadSettings();
+
+this.addCommand({
+id: 'sample-command',
+name: 'Sample Command',
+callback: () => new Notice('Sample command triggered'),
+});
+
+this.addSettingTab(new SampleSettingTab(this.app, this));
+}
+
+onunload() {
+console.log('Unloading plugin ' + this.manifest.id);
+}
+
+async loadSettings() {
+this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+}
+
+async saveSettings() {
+await this.saveData(this.settings);
+}
+}
+
+class SampleSettingTab extends PluginSettingTab {
+plugin: SamplePlugin;
+
+constructor(app: App, plugin: SamplePlugin) {
+super(app, plugin);
+this.plugin = plugin;
+}
+
+display(): void {
+const { containerEl } = this;
+containerEl.empty();
+
+new Setting(containerEl)
+.setName('Sample Setting')
+.setDesc('A simple example setting')
+.addText(text => text
+.setPlaceholder('Enter value')
+.setValue(this.plugin.settings.mySetting)
+.onChange(async (value) => {
+this.plugin.settings.mySetting = value;
+await this.plugin.saveSettings();
+}));
+}
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1 @@
+/* Sample plugin styles */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold plugin source under `src/`
- add basic manifest and build configuration
- provide GitHub issue templates and CI workflow
- document new folder structure in README

## Testing
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_684346afa4448322b0f74b8a11d70645