### PR TITLE
Add project setup script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: 📦 Install dependencies
-        run: | #List dependencies here
-          echo "Installing dependencies..."
-          # Example: pip install -r requirements.txt
-          # Replace with actual commands for your project
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm run setup
       

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/main.js",
   "scripts": {
     "dev": "rollup -c -w",
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "setup": "bash ./setup.sh"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.1.0",

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+npm install
+npm run build


### PR DESCRIPTION
## Summary
- add a `setup.sh` script to install deps and build
- include a `setup` npm script
- run the setup step in the CI workflow

## Testing
- `npm run setup` *(fails: 403 Forbidden when attempting to install packages)*
