### PR TITLE
Fix issue template links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,5 +1,5 @@
-name: 🪲 Bug Report (Plugin Related)
-description: Report a bug or glitch with this plugin template.
+name: 🪲 Bug Report (Obsidian Plugin)
+description: Report a bug or glitch with this Obsidian plugin template.
 title: 'Bug: {Issue Summary}'
 labels:
 - bug

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve the plugin
+about: Create a report to help us improve this Obsidian plugin
 labels: bug
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: 🌟 Feature Request
-description: Suggest a new template, tool, or workflow for this plugin project.
+description: Suggest a new feature or improvement for this Obsidian plugin.
 title: 'Feature: {Idea}'
 labels:
 - feature request

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this plugin
+about: Suggest an idea or improvement for this Obsidian plugin
 labels: enhancement
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This repo is built on curiosity, creativity, and care — and *you* are part of 
 🪄 Whether you're a coder, documenter, designer, or dreamer — here are some great ways to help:
 
 - 📚 Improve documentation or fix typos  
-- 🐛 Report bugs (see our [Bug Report Template](.github/ISSUE_TEMPLATE/bug_report.yml))  
+- 🐛 Report bugs (see our [Bug Report Template](.github/ISSUE_TEMPLATE/bug.yml))
 - 🌟 Suggest new features or enhancements  
 - 🧪 Write or improve tests  
 - 🔧 Refactor or optimize code  

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ We welcome contributions of all kinds!
 
 Use our templates to get started:
 
-- [🐛 Bug Reports](./.github/ISSUE_TEMPLATE/bug_report.md)
-- [🌟 Feature Requests](./.github/ISSUE_TEMPLATE/feature_request.md)
-- [📦 Pull Requests](./.github/PULL_REQUEST_TEMPLATE.md)
+- [🐛 Bug Reports](./.github/ISSUE_TEMPLATE/bug.yml)
+- [🌟 Feature Requests](./.github/ISSUE_TEMPLATE/feature-request.yml)
+- [📦 Pull Requests](./.github/pull_request_template.md)
 
 Read our [CONTRIBUTING.md](CONTRIBUTING.md) for more info, or start a conversation in [💬 GitHub Discussions](https://github.com/your-username/vaultos-plugin-template/discussions).
 


### PR DESCRIPTION
## Summary
- update README links to bug/feature templates
- fix bug report link in CONTRIBUTING guide
- call out Obsidian plugin in issue templates

## Testing
- `npm run build` *(fails: rollup not found)*
